### PR TITLE
#29: Add the ability to preview CSV files

### DIFF
--- a/force-app/main/default/classes/GoogleCloudConstants.cls
+++ b/force-app/main/default/classes/GoogleCloudConstants.cls
@@ -1,4 +1,15 @@
 public class GoogleCloudConstants {
 	public static final String DEFAULT_FILE_NAME = 'Unknown';
     public static final String DEFAULT_LOGGER_TAG = 'Google Client for Salesforce';
+	public static final Map<String, String> FILE_EXTENSION_TO_PREVIEW_TYPE = new Map<String, String>{
+		'application/msword' => 'application/vnd.google-apps.document',
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'application/vnd.google-apps.document',
+		'image/png' => 'application/vnd.google-apps.document',
+		'image/jpeg' => 'application/vnd.google-apps.document',
+		'image/webp' => 'application/vnd.google-apps.document',
+		'image/tiff' => 'application/vnd.google-apps.document',
+		'text/csv' => 'application/vnd.google-apps.spreadsheet',
+		'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'application/vnd.google-apps.spreadsheet',
+		'application/vnd.google-apps.spreadsheet' => 'application/vnd.google-apps.spreadsheet'
+	};
 }

--- a/force-app/main/default/classes/commands/GoogleFileStoreInFolderCommand.cls
+++ b/force-app/main/default/classes/commands/GoogleFileStoreInFolderCommand.cls
@@ -49,7 +49,7 @@ public without sharing class GoogleFileStoreInFolderCommand {
         Logger.info(
             'Folder Placement Job --> RemoteIds' +
             ', GoogleDriveFileId=' + String.valueOf(remoteFileIds == null ? null : remoteFileIds.googleDriveFileId) +
-            ', GoogleDocsFileId=' + String.valueOf(remoteFileIds == null ? null : remoteFileIds.googleDocsFileId)
+            ', GoogleWorkspaceFileId=' + String.valueOf(remoteFileIds == null ? null : remoteFileIds.googleWorkspaceFileId)
         ).addTag(GoogleCloudConstants.DEFAULT_LOGGER_TAG);
 
         if (remoteFileIds == null || String.isBlank(remoteFileIds.googleDriveFileId)) {
@@ -97,8 +97,8 @@ public without sharing class GoogleFileStoreInFolderCommand {
         String resultingGoogleDriveFileId = movedFile == null ? null : movedFile.id;
         if (String.isBlank(resultingGoogleDriveFileId)) return;
 
-        if (!String.isBlank(remoteFileIds.googleDocsFileId)) {
-            moveRemoteFile(remoteFileIds.googleDocsFileId, uploadParentFolderIds, destinationFolderId);
+        if (!String.isBlank(remoteFileIds.googleWorkspaceFileId)) {
+            moveRemoteFile(remoteFileIds.googleWorkspaceFileId, uploadParentFolderIds, destinationFolderId);
         }
 
         registerLatestVersionFolderUpdate(
@@ -328,11 +328,11 @@ public without sharing class GoogleFileStoreInFolderCommand {
 
     private class RemoteFileIds {
         public String googleDriveFileId;
-        public String googleDocsFileId;
+        public String googleWorkspaceFileId;
 
-        public RemoteFileIds(String googleDriveFileId, String googleDocsFileId) {
+        public RemoteFileIds(String googleDriveFileId, String googleWorkspaceFileId) {
             this.googleDriveFileId = googleDriveFileId;
-            this.googleDocsFileId = googleDocsFileId;
+            this.googleWorkspaceFileId = googleWorkspaceFileId;
         }
     }
 }

--- a/force-app/main/default/classes/jobs/GoogleFileVersionPreviewJob.cls
+++ b/force-app/main/default/classes/jobs/GoogleFileVersionPreviewJob.cls
@@ -3,13 +3,13 @@ public with sharing class GoogleFileVersionPreviewJob implements Queueable, Data
 
     private final Set<Id> versionIds;
     public GoogleFileVersionPreviewJob(Set<Id> versionIds) {
-        this.versionIds = versionIds == null 
+        this.versionIds = versionIds == null
 			? new Set<Id>()
 			: new Set<Id>(versionIds);
     }
 
     public void execute(QueueableContext qc) {
-		Logger.info('Queueable Job to generate Google Docs previews for: ' + String.join(versionIds, ', ')).addTag(GoogleCloudConstants.DEFAULT_LOGGER_TAG);
+		Logger.info('Queueable Job to generate Google Workspace previews for: ' + String.join(versionIds, ', ')).addTag(GoogleCloudConstants.DEFAULT_LOGGER_TAG);
         if (versionIds.isEmpty()) return;
 
 		List<GoogleFileVersion__c> localFileVersions = (List<GoogleFileVersion__c>) GoogleFileVersionSelector.query()
@@ -21,16 +21,19 @@ public with sharing class GoogleFileVersionPreviewJob implements Queueable, Data
         for (GoogleFileVersion__c localFileVersion : localFileVersions) {
             if (String.isNotBlank(localFileVersion.GoogleDocsFileId__c)) continue;
 
+			String targetGoogleWorkspaceType = GoogleCloudConstants.FILE_EXTENSION_TO_PREVIEW_TYPE.get(localFileVersion.Type__c);
+			if (String.isBlank(targetGoogleWorkspaceType)) continue;
+
 			GoogleDriveApiProvider remoteFileService = new GoogleDriveApiProvider();
 			GoogleDrive removeGoogleDrive = remoteFileService.retrieveGoogleDriveClient();
 			GoogleFileEntity clonedFile = removeGoogleDrive.files().clone(localFileVersion.GoogleDriveFileId__c)
 				.setFields('id')
 				.setFileName(localFileVersion.Name)
 				.setSupportsAllDrives(true)
-				.setMimeType('application/vnd.google-apps.document')
+				.setMimeType(targetGoogleWorkspaceType)
 				.execute();
 
-			localFileVersion.GoogleDocsFileId__c  = clonedFile.id;
+			localFileVersion.GoogleDocsFileId__c = clonedFile.id;
 			toUpdate.add(localFileVersion);
         }
 

--- a/force-app/main/default/objects/GoogleFileVersion__c/fields/GoogleDocsFileId__c.field-meta.xml
+++ b/force-app/main/default/objects/GoogleFileVersion__c/fields/GoogleDocsFileId__c.field-meta.xml
@@ -4,7 +4,7 @@
     <deprecated>false</deprecated>
     <description>Converted the original document to a Google Workspace type to enable exporting this type in another format.</description>
     <externalId>false</externalId>
-    <label>Google Docs File Id</label>
+    <label>Google Workspace File Id</label>
     <length>255</length>
     <required>false</required>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/GoogleFileVersion__c/fields/IsPreviewableFile__c.field-meta.xml
+++ b/force-app/main/default/objects/GoogleFileVersion__c/fields/IsPreviewableFile__c.field-meta.xml
@@ -10,7 +10,10 @@
   Type__c = &quot;image/png&quot;,
   Type__c = &quot;image/jpeg&quot;,
   Type__c = &quot;image/webp&quot;,
-  Type__c = &quot;image/tiff&quot;
+  Type__c = &quot;image/tiff&quot;,
+  Type__c = &quot;text/csv&quot;,
+  Type__c = &quot;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet&quot;,
+  Type__c = &quot;application/vnd.google-apps.spreadsheet&quot;
 )</formula>
     <label>Is Previewable File?</label>
     <trackTrending>false</trackTrending>


### PR DESCRIPTION
This change expands the list of supported file types in the formula and enhances GoogleFileVersionPreviewJob so it no longer always creates a Google Doc preview.

The job now checks the original file type against the FILE_EXTENSION_TO_PREVIEW_TYPE map and selects the appropriate Google Workspace file type to create.

This enables conversion of supported source files into Google Workspace files, which can then be exported as PDF. This is required because the Google Drive API cannot export the original uploaded files directly, as they are treated only as blob files and do not support export operations.