### PR TITLE
#59: Share Fails When Experience Cloud Is Disabled & Analytics Is Not Visible for Non-System Admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - 2026-04-27
+
+### Fixed
+
+- Organizations with Experience Cloud fully disabled could not share files because the isPortalEnabled field was not accessible.
+- Non-admin users without View All Data, but assigned the Google Cloud Client Admin permission set, could not run reports and therefore could not view the Analytics dashboard.
+
 ## [1.3.0] - 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This client depends on two required packages, which **must be installed first**:
 <p>Use this option to test Google Client for Salesforce before installing it in production.</p>
 
 <p>
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVaIAM" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Install%20Google%20Client%20for%20Salesforce-Sandbox-0176D3?style=for-the-badge&logo=salesforce&logoColor=white" alt="Install Google Client for Salesforce in Sandbox" height="52"></a>
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVpIAM" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Install%20Google%20Client%20for%20Salesforce-Sandbox-0176D3?style=for-the-badge&logo=salesforce&logoColor=white" alt="Install Google Client for Salesforce in Sandbox" height="52"></a>
 </p>
 
 <br />
@@ -67,7 +67,7 @@ This client depends on two required packages, which **must be installed first**:
 <p>Use this option when you are ready to install the package in your production org.</p>
 
 <p>
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVaIAM" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Install%20Google%20Client%20for%20Salesforce-Production-0176D3?style=for-the-badge&logo=salesforce&logoColor=white" alt="Install Google Client for Salesforce in Production" height="52"></a>
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVpIAM" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Install%20Google%20Client%20for%20Salesforce-Production-0176D3?style=for-the-badge&logo=salesforce&logoColor=white" alt="Install Google Client for Salesforce in Production" height="52"></a>
 </p>
 
 </div>
@@ -77,7 +77,7 @@ This client depends on two required packages, which **must be installed first**:
 ### CLI Installation
 
 ```bash
-sf package install --wait 20 --security-type AdminsOnly --package 04tJ80000011MVaIAM
+sf package install --wait 20 --security-type AdminsOnly --package 04tJ80000011MVpIAM
 ```
 
 <br />

--- a/docs/media/videos.md
+++ b/docs/media/videos.md
@@ -5,4 +5,9 @@
 
     [Watch on YouTube](https://www.youtube.com/watch?v=sdg7v8cvjMY){ target="_blank" rel="noopener noreferrer" }
 
+???+ video "Quick Overview of Release v1.3.0"
+    How Google Client for Salesforce is moving beyond file storage replacement and becoming a smarter, more secure, and more observable file management layer for Salesforce.
+
+    [Watch on YouTube](https://www.youtube.com/watch?v=cyVFIoocE4I){ target="_blank" rel="noopener noreferrer" }
+
 <br>

--- a/docs/setup/install-and-dependencies.md
+++ b/docs/setup/install-and-dependencies.md
@@ -12,10 +12,10 @@ Two packages are required before installing Google Client for Salesforce. If you
 Install Google Client for Salesforce using one of the options below.
 
 <div style="display: flex; justify-content: center; gap: 12px; margin-bottom: 16px;">
-  <a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVaIAM" target="_blank" rel="noopener noreferrer">
+  <a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVpIAM" target="_blank" rel="noopener noreferrer">
     <img src="https://img.shields.io/badge/Install%20In%20Sandbox-blue?style=for-the-badge&logo=salesforce" alt="Install the Unlocked Package in Sandbox">
   </a>
-  <a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVaIAM" target="_blank" rel="noopener noreferrer">
+  <a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVpIAM" target="_blank" rel="noopener noreferrer">
     <img src="https://img.shields.io/badge/Install%20In%20Production-blue?style=for-the-badge&logo=salesforce" alt="Install the Unlocked Package in Production">
   </a>
 </div>
@@ -23,7 +23,7 @@ Install Google Client for Salesforce using one of the options below.
 Or via CLI:
 
 ```bash
-sf package install --wait 20 --security-type AdminsOnly --package 04tJ80000011MVaIAM
+sf package install --wait 20 --security-type AdminsOnly --package 04tJ80000011MVpIAM
 ```
 
 Once both dependencies and the package are installed, proceed to [Set Up Service Account](setup-service-account.md).

--- a/docs/validation/release-validation-log.md
+++ b/docs/validation/release-validation-log.md
@@ -2,6 +2,29 @@
 
 This document tracks **test coverage, validation scenarios, and release checks** for each release of **Google Client for Salesforce**. The goal is to ensure that all critical features, integrations, and edge cases are tested when creating a new version.
 
+???+ example "Hotfix v1.3.1"
+
+    ### Validation Suite Used
+    - [ ] Full Validation Suite
+    - [ ] Quick Regression Suite
+    - [X] Targeted Regression Suite
+
+    ### Release Changes
+    - [X] Fixed 1: Create a new organization where Experience Cloud is fully disabled under Digital Experiences → Settings. Upload a new file and verify that it can be shared without errors.
+    - [X] Fixed 2: Create a new user with the Salesforce license and Standard User profile, then assign the Google Cloud Client Admin permission set. Open the Google Client application and verify that the user can access the Analytics tab and view the dashboard inside it.
+
+    ### Boring Changes
+    - [X] Version number assigned to all hard-coded labels
+    - [X] Version ID is assigned to all installation guides.
+
+    ### Smoke Checks
+    - [X] Internal user (Core Cloud) can open Lightning record pages containing Google Client components without errors
+    - [X] External user (Experience Cloud) can open Experience Cloud pages containing Google Client components without errors
+    - [X] Admin can open Google Client app and browse configuration tabs without errors
+
+    ### Notes
+    - When promoting a new package version, if the installation fails, unassign the Google Cloud Client Admin permission set from all users, then try the installation again.
+
 ???+ example "Release v1.3.0"
 
     ### Validation Suite Used

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -33,7 +33,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>GoogleClientReleaseTitle</shortDescription>
-        <value>Google Client v.1.3.0</value>
+        <value>Google Client v.1.3.1</value>
     </labels>
     <labels>
         <fullName>GoogleClientSupportEmail</fullName>

--- a/force-app/main/default/lwc/googleCloudFileSharing/googleCloudFileSharing.html
+++ b/force-app/main/default/lwc/googleCloudFileSharing/googleCloudFileSharing.html
@@ -26,7 +26,8 @@
                             placeholder={selectFromObjectPlaceholder}
                             object-api-name={selectFromObjectApiName}
                             filter={selectFromObjectFilters}
-                            onchange={handleShareRecordChange}>
+                            onchange={handleShareRecordChange}
+                            onerror={handleRecordPickerError}>
                         </lightning-record-picker>
                     </div>
                     <div class="slds-col slds-grow">

--- a/force-app/main/default/lwc/googleCloudFileSharing/googleCloudFileSharing.js
+++ b/force-app/main/default/lwc/googleCloudFileSharing/googleCloudFileSharing.js
@@ -19,6 +19,7 @@ export default class GoogleCloudFileSharing extends LightningElement {
 	@track isLoading = true;
 
 	@track userId = Id;
+	@track isPortalFilterSupported = true;
 
 	connectedCallback() {
 		this.setDefaultValues();
@@ -35,6 +36,12 @@ export default class GoogleCloudFileSharing extends LightningElement {
 
 	handleShareRecordChange(event) {
 		this.selectedShareToRecordId = event.detail.recordId;
+	}
+
+	handleRecordPickerError(event) {
+		if (event.detail?.error?.errorCode === 'ERR_RP005' || event.detail?.error?.errorCode === 'ERR_RP008') {
+			this.isPortalFilterSupported = false;
+		}
 	}
 
 	async handleNewSharingClick(event) {
@@ -276,6 +283,28 @@ export default class GoogleCloudFileSharing extends LightningElement {
 
 	get selectFromObjectFilters() {
 		if (this.selectFromObjectApiName === 'User') {
+			if (this.isPortalFilterSupported) {
+				return {
+					criteria: [
+						{
+							fieldPath: 'IsActive',
+							operator: 'eq',
+							value: true
+						},
+						{
+							fieldPath: 'IsPortalEnabled',
+							operator: 'eq',
+							value: false
+						},
+						{
+							fieldPath: 'Id',
+							operator: 'nin',
+							value: this.userIdsToExclude
+						}
+					],
+					filterLogic: '1 AND 2 AND 3'
+				};
+			}
 			return {
 				criteria: [
 					{
@@ -284,17 +313,12 @@ export default class GoogleCloudFileSharing extends LightningElement {
 						value: true
 					},
 					{
-						fieldPath: 'IsPortalEnabled',
-						operator: 'eq',
-						value: false
-					},
-					{
 						fieldPath: 'Id',
 						operator: 'nin',
 						value: this.userIdsToExclude
 					}
 				],
-				filterLogic: '1 AND 2 AND 3'
+				filterLogic: '1 AND 2'
 			};
 		} else {
 			return {

--- a/force-app/main/default/permissionsets/GoogleCloudClientAdmin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/GoogleCloudClientAdmin.permissionset-meta.xml
@@ -86,6 +86,10 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
+        <name>RunReports</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
         <name>ViewRoles</name>
     </userPermissions>
     <userPermissions>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "Salesforce Google Client",
-      "versionName": "Version 1.3.0",
-      "versionNumber": "1.3.0.NEXT",
+      "versionName": "Version 1.3.1",
+      "versionNumber": "1.3.1.NEXT",
       "versionDescription": "An integrated Google Cloud solution on the Salesforce platform designed to simplify file management and improve productivity at scale",
       "releaseNotesUrl": "https://github.com/sandriiy/salesforce-google-client/releases",
       "dependencies": [
@@ -30,6 +30,7 @@
     "Salesforce Google Client@1.1.0-1": "04tJ80000011MEqIAM",
     "Salesforce Google Client@1.2.0-1": "04tJ80000011MKfIAM",
     "Salesforce Google Client@1.3.0-1": "04tJ80000011MVVIA2",
-    "Salesforce Google Client@1.3.0-2": "04tJ80000011MVaIAM"
+    "Salesforce Google Client@1.3.0-2": "04tJ80000011MVaIAM",
+    "Salesforce Google Client@1.3.1-1": "04tJ80000011MVpIAM"
   }
 }


### PR DESCRIPTION
- When Experience Cloud is disabled for the organization, the Share button fails because the IsPortalEnabled field is not accessible.
- When the Google Admin User permission set is assigned to a user without System Administrator access, the Analytics tab is not displayed properly.