### PR TITLE
#68 / Hotfix: Multiple record folders are created when uploading several files to a record without an existing folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.2] - 2026-06-08
+
+### Fixed
+
+- Uploading multiple files at once to a record without an existing resolved Google Drive folder could create multiple folders for the same record when Google Client was configured to use a dedicated folder per record.
+- Files uploaded from the File Explorer tab/component could be placed into a user-specific Google Drive folder even when the folder per user option was not enabled.
+
 ## [1.3.1] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This client depends on two required packages, which **must be installed first**:
 <p>Use this option to test Google Client for Salesforce before installing it in production.</p>
 
 <p>
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVpIAM" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Install%20Google%20Client%20for%20Salesforce-Sandbox-0176D3?style=for-the-badge&logo=salesforce&logoColor=white" alt="Install Google Client for Salesforce in Sandbox" height="52"></a>
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQy000000VyHdIAK" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Install%20Google%20Client%20for%20Salesforce-Sandbox-0176D3?style=for-the-badge&logo=salesforce&logoColor=white" alt="Install Google Client for Salesforce in Sandbox" height="52"></a>
 </p>
 
 <br />
@@ -67,7 +67,7 @@ This client depends on two required packages, which **must be installed first**:
 <p>Use this option when you are ready to install the package in your production org.</p>
 
 <p>
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVpIAM" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Install%20Google%20Client%20for%20Salesforce-Production-0176D3?style=for-the-badge&logo=salesforce&logoColor=white" alt="Install Google Client for Salesforce in Production" height="52"></a>
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQy000000VyHdIAK" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Install%20Google%20Client%20for%20Salesforce-Production-0176D3?style=for-the-badge&logo=salesforce&logoColor=white" alt="Install Google Client for Salesforce in Production" height="52"></a>
 </p>
 
 </div>
@@ -77,7 +77,7 @@ This client depends on two required packages, which **must be installed first**:
 ### CLI Installation
 
 ```bash
-sf package install --wait 20 --security-type AdminsOnly --package 04tJ80000011MVpIAM
+sf package install --wait 20 --security-type AdminsOnly --package 04tQy000000VyHdIAK
 ```
 
 <br />

--- a/docs/setup/install-and-dependencies.md
+++ b/docs/setup/install-and-dependencies.md
@@ -12,10 +12,10 @@ Two packages are required before installing Google Client for Salesforce. If you
 Install Google Client for Salesforce using one of the options below.
 
 <div style="display: flex; justify-content: center; gap: 12px; margin-bottom: 16px;">
-  <a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVpIAM" target="_blank" rel="noopener noreferrer">
+  <a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04tQy000000VyHdIAK" target="_blank" rel="noopener noreferrer">
     <img src="https://img.shields.io/badge/Install%20In%20Sandbox-blue?style=for-the-badge&logo=salesforce" alt="Install the Unlocked Package in Sandbox">
   </a>
-  <a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tJ80000011MVpIAM" target="_blank" rel="noopener noreferrer">
+  <a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04tQy000000VyHdIAK" target="_blank" rel="noopener noreferrer">
     <img src="https://img.shields.io/badge/Install%20In%20Production-blue?style=for-the-badge&logo=salesforce" alt="Install the Unlocked Package in Production">
   </a>
 </div>
@@ -23,7 +23,7 @@ Install Google Client for Salesforce using one of the options below.
 Or via CLI:
 
 ```bash
-sf package install --wait 20 --security-type AdminsOnly --package 04tJ80000011MVpIAM
+sf package install --wait 20 --security-type AdminsOnly --package 04tQy000000VyHdIAK
 ```
 
 Once both dependencies and the package are installed, proceed to [Set Up Service Account](setup-service-account.md).

--- a/docs/validation/release-validation-log.md
+++ b/docs/validation/release-validation-log.md
@@ -2,6 +2,39 @@
 
 This document tracks **test coverage, validation scenarios, and release checks** for each release of **Google Client for Salesforce**. The goal is to ensure that all critical features, integrations, and edge cases are tested when creating a new version.
 
+???+ example "Hotfix v1.3.2"
+
+    ### Validation Suite Used
+    - [ ] Full Validation Suite
+    - [ ] Quick Regression Suite
+    - [X] Targeted Regression Suite
+
+    ### Release Changes
+    - [X] Fixed 1: When Google Client is configured to use a dedicated folder per record, uploading multiple files to a record that does not yet have any Google files creates multiple Google Drive folders for the same record. This issue appears to happen only when multiple files are uploaded at once and the record does not already have a resolved folder. After the first upload is completed, subsequent uploads to the same record are stored in a single folder as expected. For reference: https://github.com/sandriiy/salesforce-google-client/issues/68
+
+    ### Boring Changes
+    - [X] Version number assigned to all hard-coded labels
+    - [X] Version ID is assigned to all installation guides.
+
+    ### Smoke Checks
+    - [X] Internal user (Core Cloud) can open Lightning record pages containing Google Client components without errors
+    - [X] External user (Experience Cloud) can open Experience Cloud pages containing Google Client components without errors
+    - [X] Admin can open Google Client app and browse configuration tabs without errors
+
+	### Specific Checks
+	- [X] With **Folder Structure** not configured at all, a regular user uploaded single, multiple, small, and large files from **Attachments**, **Uploader**, and **File Explorer** without any issues. Uploaded files stayed in the root Google Drive folder, and no sub-folder was created.
+	- [X] After admin changed **Folder Structure** to **Folder per User**, a regular user uploaded files from all three places without any issues. Uploaded files were placed in that user’s own folder.
+	- [X] With **Folder per User** configured, a regular user shared files with another internal user using both **Viewer** and **Collaborator** access. The second user was able to access those files, and when he uploaded his own file, it was placed in his own separate user folder.
+	- [X] After admin changed **Folder Structure** to **Folder per Record**, a regular user uploaded files from all three places without any issues. Files uploaded to records were placed in the folder created for the related record. The user tested several Account records, and only one folder was created per record.
+	- [X] Another internal user uploaded files to a record where the folder had already been created by the first user. New files were placed in the same existing record folder, and no duplicate folder was created.
+	- [X] After admin changed **Folder Structure** to **Folder per Record → Folder per User**, a regular user uploaded files from all three places without any issues. Files were placed inside the related record folder, under a sub-folder created for that user.
+	- [X] After admin changed **Folder Structure** to **Folder per User → Folder per Record**, a regular user uploaded files from all three places without any issues. Files were placed inside the user folder, under sub-folders created for each related record.
+	- [X] A user shared several files with an external user. The external user was able to see those files. After more single and multiple files were uploaded, all new files were placed in the already existing folder.
+
+    ### Notes
+    - As part of this hotfix, I also fixed an issue where files uploaded from the **File Explorer** component, which means without a record ID, could still trigger the asynchronous Google Drive folder-structure job to create a **User** folder, even when the **User** folder option was not enabled in the "Google Client" settings. Since this behavior does not seem to match the expected configuration, the job now respects the folder-structure settings. If the **User** folder is not selected, it will not be created.
+
+
 ???+ example "Hotfix v1.3.1"
 
     ### Validation Suite Used

--- a/force-app/main/default/classes/GoogleCloudFilesController.cls
+++ b/force-app/main/default/classes/GoogleCloudFilesController.cls
@@ -99,6 +99,18 @@ public with sharing class GoogleCloudFilesController {
         return retrieveGoogleFiles(relatedRecordId, source, recordsCount);
     }
 
+	@AuraEnabled
+	public static void ensureGoogleDriveFolderStructure(Id relatedRecordId) {
+		try {
+			GoogleLocalFileService recordService = new GoogleLocalFileService();
+			recordService.ensureGoogleDriveFolderStructure(relatedRecordId);
+		} catch (Exception ex) {
+			Logger.error('Ensure Google Drive Folder Structure, Record Id: ' + relatedRecordId).addTag(GoogleCloudConstants.DEFAULT_LOGGER_TAG);
+			Logger.error('Ensure Google Drive Folder Structure, Message: ' + ex.getMessage()).addTag(GoogleCloudConstants.DEFAULT_LOGGER_TAG);
+			Logger.saveLog();
+		}
+	}
+
     @AuraEnabled
     public static GoogleFile__c saveNewGoogleFile(Id recordId, String fileName, String fileType, Long fileSize, String googleDriveId, String parentFolderId, String source) {
         GoogleFileCreateRequestDTO request = new GoogleFileCreateRequestDTO();

--- a/force-app/main/default/classes/commands/GoogleFileFolderStructureCommand.cls
+++ b/force-app/main/default/classes/commands/GoogleFileFolderStructureCommand.cls
@@ -1,0 +1,216 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Andrii Sukhetskyi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+public without sharing class GoogleFileFolderStructureCommand {
+	public class GoogleFileFolderStructureCommandException extends Exception {}
+
+	private static final String FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
+	private static final String APP_PROPERTY_RECORD_ID = 'record-id';
+	private static final String STRUCTURE_USER = '{User}';
+	private static final String STRUCTURE_RECORD = '{Record}';
+	private static final String STRUCTURE_USER_RECORD = '{User}-{Record}';
+	private static final String STRUCTURE_RECORD_USER = '{Record}-{User}';
+
+	private final GoogleDrive remoteGoogleDrive;
+	private final GoogleMetadataConfigService metadataService;
+	private final GoogleLocalFileLinkEnrichmentService linkEnrichmentService;
+
+	public GoogleFileFolderStructureCommand() {
+		this.remoteGoogleDrive = new GoogleClientApiProvider().retrieveGoogleDriveClient();
+		this.metadataService = new GoogleMetadataConfigService();
+		this.linkEnrichmentService = new GoogleLocalFileLinkEnrichmentService();
+	}
+
+	public String ensureFolder(Id relatedRecordId) {
+		return ensureFolder(UserInfo.getUserId(), relatedRecordId);
+	}
+
+	public String ensureFolder(Id initiatorUserId, Id relatedRecordId) {
+		return resolveFolderId(initiatorUserId, relatedRecordId, true);
+	}
+
+	public String findExistingFolder(Id initiatorUserId, Id relatedRecordId) {
+		return resolveFolderId(initiatorUserId, relatedRecordId, false);
+	}
+
+	private String resolveFolderId(Id initiatorUserId, Id relatedRecordId, Boolean createIfMissing) {
+		List<String> uploadParentFolderIds = metadataService.getTargetFolderResolver().resolveUploadFolderId();
+		String rootFolderId = getFirstFolderId(uploadParentFolderIds);
+		if (String.isBlank(rootFolderId)) return null;
+
+		String folderStructure = metadataService.getGoogleDriveFolderStructure();
+		if (String.isBlank(folderStructure)) return null;
+
+		FolderTargets folderTargets = buildFolderTargets(initiatorUserId, relatedRecordId);
+		return resolveDestinationFolderId(folderStructure, rootFolderId, initiatorUserId, folderTargets.userFolderName, folderTargets.relatedRecordId, folderTargets.recordFolderName, createIfMissing);
+	}
+
+	private FolderTargets buildFolderTargets(Id initiatorUserId, Id relatedRecordId) {
+		FolderTargets targets = new FolderTargets();
+		targets.relatedRecordId = relatedRecordId;
+		targets.userFolderName = buildUserFolderName(initiatorUserId);
+		targets.recordFolderName = buildRecordFolderName(relatedRecordId);
+		return targets;
+	}
+
+	private String buildUserFolderName(Id userId) {
+		User initiatingUser = loadUser(userId);
+		if (initiatingUser == null) return 'Unknown User';
+
+		String fullName = String.join(new List<String>{
+			String.isBlank(initiatingUser.FirstName) ? null : initiatingUser.FirstName,
+			String.isBlank(initiatingUser.LastName) ? null : initiatingUser.LastName
+		}, ' ').trim();
+
+		return 'User : ' + fullName;
+	}
+
+	private User loadUser(Id userId) {
+		if (userId == null) return null;
+
+		List<User> users = [
+			SELECT Id, FirstName, LastName
+			FROM User
+			WHERE Id = :userId
+			LIMIT 1
+		];
+
+		return users.isEmpty() ? null : users[0];
+	}
+
+	private String buildRecordFolderName(Id relatedRecordId) {
+		if (relatedRecordId == null) return null;
+
+		Schema.SObjectType objectType = relatedRecordId.getSObjectType();
+		String objectApiName = objectType.getDescribe().getName();
+		String recordName = linkEnrichmentService.resolveLinkedRecordName(relatedRecordId);
+
+		return objectApiName + ' : ' + (String.isBlank(recordName) ? 'Unknown Record' : recordName);
+	}
+
+	private String resolveDestinationFolderId(String folderStructure, String rootFolderId, Id userId, String userFolderName, Id recordId, String recordFolderName, Boolean createIfMissing) {
+		if (String.isBlank(folderStructure)) return null;
+
+		if (folderStructure == STRUCTURE_USER) {
+			return resolveFolder(rootFolderId, userFolderName, userId, createIfMissing);
+		}
+
+		if (folderStructure == STRUCTURE_RECORD) {
+			if (recordId == null) return null;
+			return resolveFolder(rootFolderId, recordFolderName, recordId, createIfMissing);
+		}
+
+		if (folderStructure == STRUCTURE_USER_RECORD) {
+			if (recordId == null) return null;
+			String userFolderId = resolveFolder(rootFolderId, userFolderName, userId, createIfMissing);
+			if (String.isBlank(userFolderId)) return null;
+
+			return resolveFolder(userFolderId, recordFolderName, recordId, createIfMissing);
+		}
+
+		if (folderStructure == STRUCTURE_RECORD_USER) {
+			if (recordId == null) return null;
+			String recordFolderId = resolveFolder(rootFolderId, recordFolderName, recordId, createIfMissing);
+			if (String.isBlank(recordFolderId)) return null;
+
+			return resolveFolder(recordFolderId, userFolderName, userId, createIfMissing);
+		}
+
+		return null;
+	}
+
+	private String resolveFolder(String parentFolderId, String folderName, Id uniqueIdValue, Boolean createIfMissing) {
+		if (String.isBlank(parentFolderId) || uniqueIdValue == null) return null;
+
+		String existingFolderId = findFolderIdByUniqueId(parentFolderId, uniqueIdValue);
+		if (String.isNotBlank(existingFolderId)) {
+			return existingFolderId;
+		}
+
+		if (createIfMissing != true) return null;
+
+		return createFolder(parentFolderId, folderName, uniqueIdValue);
+	}
+
+	private String findFolderIdByUniqueId(String parentFolderId, Id uniqueIdValue) {
+		String escapedParentId = escapeQueryValue(parentFolderId);
+		String escapedUniqueId = escapeQueryValue(uniqueIdValue);
+
+		String query = 'mimeType = \'' + FOLDER_MIME_TYPE + '\' ';
+		query += 'and \'' + escapedParentId + '\' in parents ';
+		query += 'and trashed = false ';
+		query += 'and appProperties has { key=\'' + APP_PROPERTY_RECORD_ID + '\' and value=\'' + escapedUniqueId + '\' }';
+
+		GoogleFileSearchResult searchResult = remoteGoogleDrive.files().search()
+			.setMaxResult(1)
+			.setSearchQuery(query)
+			.setSearchOnAllDrives(true)
+			.setFields('files(id,name)')
+			.execute();
+
+		if (searchResult != null && searchResult.files != null && !searchResult.files.isEmpty()) {
+			return searchResult.files[0].id;
+		}
+
+		return null;
+	}
+
+	private String createFolder(String parentFolderId, String folderName, Id uniqueIdValue) {
+		Map<String, Object> customAttributes = new Map<String, Object>{
+			APP_PROPERTY_RECORD_ID => uniqueIdValue
+		};
+
+		String entityName = String.isBlank(folderName) ? 'Untitled' : folderName.trim();
+		GoogleFileEntity createdFolder = remoteGoogleDrive.files().multipartCreate()
+			.setFileName(entityName)
+			.setMimeType(FOLDER_MIME_TYPE)
+			.setParentFolders(new List<String>{ parentFolderId })
+			.setCustomAttributes(customAttributes)
+			.setSupportsAllDrives(true)
+			.setBody('')
+			.execute();
+
+		return createdFolder == null ? null : createdFolder.id;
+	}
+
+	private String getFirstFolderId(List<String> folderIds) {
+		if (folderIds == null || folderIds.isEmpty()) return null;
+
+		for (String folderId : folderIds) {
+			if (String.isNotBlank(folderId)) return folderId;
+		}
+
+		return null;
+	}
+
+	private String escapeQueryValue(String value) {
+		if (value == null) return '';
+		return value.replace('\\', '\\\\').replace('\'', '\\\'');
+	}
+
+	private class FolderTargets {
+		public String userFolderName;
+		public String recordFolderName;
+		public Id relatedRecordId;
+	}
+}

--- a/force-app/main/default/classes/commands/GoogleFileFolderStructureCommand.cls-meta.xml
+++ b/force-app/main/default/classes/commands/GoogleFileFolderStructureCommand.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/commands/GoogleFileStoreInFolderCommand.cls
+++ b/force-app/main/default/classes/commands/GoogleFileStoreInFolderCommand.cls
@@ -24,21 +24,15 @@
 public without sharing class GoogleFileStoreInFolderCommand {
 	public class GoogleFileStoreInFolderCommandException extends Exception {}
 
-    private static final String FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
-    private static final String APP_PROPERTY_RECORD_ID = 'record-id';
-
-    private static final String STRUCTURE_USER = '{User}';
-    private static final String STRUCTURE_RECORD = '{Record}';
-    private static final String STRUCTURE_USER_RECORD = '{User}-{Record}';
-    private static final String STRUCTURE_RECORD_USER = '{Record}-{User}';
-
     private GoogleDrive remoteGoogleDrive;
     private GoogleMetadataConfigService metadataService;
+    private GoogleFileFolderStructureCommand folderStructureCommand;
     private final IGoogleUnitOfWork uowRef;
 
     public GoogleFileStoreInFolderCommand(IGoogleUnitOfWork uowRef) {
         this.remoteGoogleDrive = new GoogleClientApiProvider().retrieveGoogleDriveClient();
         this.metadataService = new GoogleMetadataConfigService();
+        this.folderStructureCommand = new GoogleFileFolderStructureCommand();
         this.uowRef = uowRef;
     }
 
@@ -54,16 +48,6 @@ public without sharing class GoogleFileStoreInFolderCommand {
         }
 
         List<String> uploadParentFolderIds = this.metadataService.getTargetFolderResolver().resolveUploadFolderId();
-
-        String folderStructure = this.metadataService.getGoogleDriveFolderStructure();
-        if (String.isBlank(folderStructure)) return;
-
-        Logger.info(
-            'Folder Placement Job --> Config' +
-            ', FolderStructure=' + String.valueOf(folderStructure) +
-            ', UploadParentFolderIds=' + String.valueOf(uploadParentFolderIds)
-        ).addTag(GoogleCloudConstants.DEFAULT_LOGGER_TAG);
-
         String rootFolderId = getFirstFolderId(uploadParentFolderIds);
         if (String.isBlank(rootFolderId)) return;
 
@@ -80,16 +64,12 @@ public without sharing class GoogleFileStoreInFolderCommand {
 			return;
         }
 
-        FolderTargets folderTargets = loadFolderTargets(request);
-
-        String destinationFolderId = resolveDestinationFolderId(
-            folderStructure,
-            rootFolderId,
-            request.initiatorUserId,
-            folderTargets.userFolderName,
-            folderTargets.relatedRecordId,
-            folderTargets.recordFolderName
-        );
+        Id relatedRecordId = loadRelatedRecordId(request);
+        String destinationFolderId = folderStructureCommand.findExistingFolder(request.initiatorUserId, relatedRecordId);
+        if (String.isBlank(destinationFolderId)) {
+            destinationFolderId = folderStructureCommand.ensureFolder(request.initiatorUserId, relatedRecordId);
+        }
+		
         if (String.isBlank(destinationFolderId)) return;
 
         Logger.info(
@@ -164,148 +144,17 @@ public without sharing class GoogleFileStoreInFolderCommand {
         );
     }
 
-    private FolderTargets loadFolderTargets(GoogleFileRelocationRequestDTO request) {
-        FolderTargets targets = new FolderTargets();
+    private Id loadRelatedRecordId(GoogleFileRelocationRequestDTO request) {
+        if (request == null || request.linkLocalGoogleFileId == null) return null;
 
-        GoogleFileLink__c fileLink;
-        if (request != null && request.linkLocalGoogleFileId != null) {
-            fileLink = (GoogleFileLink__c) GoogleFileLinkSelector.query()
-                .withBaseFields()
-                .byId(request.linkLocalGoogleFileId)
-                .toObject();
-        }
+        GoogleFileLink__c fileLink = (GoogleFileLink__c) GoogleFileLinkSelector.query()
+            .withBaseFields()
+            .byId(request.linkLocalGoogleFileId)
+            .toObject();
 
-        targets.userFolderName = buildUserFolderName(request == null ? null : request.initiatorUserId);
-        targets.relatedRecordId = fileLink == null || String.isBlank(fileLink.LinkedObjectId__c)
+        return fileLink == null || String.isBlank(fileLink.LinkedObjectId__c)
             ? null
             : (Id) fileLink.LinkedObjectId__c;
-        targets.recordFolderName = buildRecordFolderName(fileLink, targets.relatedRecordId);
-
-        return targets;
-    }
-
-    private String buildUserFolderName(Id userId) {
-        User initiatingUser = loadUser(userId);
-        if (initiatingUser == null) return 'Unknown User';
-
-        String fullName = String.join(new List<String>{
-            String.isBlank(initiatingUser.FirstName) ? null : initiatingUser.FirstName,
-            String.isBlank(initiatingUser.LastName) ? null : initiatingUser.LastName
-        }, ' ').trim();
-
-        return 'User : ' + fullName;
-    }
-
-    private User loadUser(Id userId) {
-        if (userId == null) return null;
-
-        List<User> users = [
-            SELECT Id, FirstName, LastName
-            FROM User
-            WHERE Id = :userId
-            LIMIT 1
-        ];
-
-        return users.isEmpty() ? null : users[0];
-    }
-
-    private String buildRecordFolderName(GoogleFileLink__c fileLink, Id relatedRecordId) {
-        if (relatedRecordId == null) return null;
-
-        String explicitType = fileLink == null ? '' : fileLink.LinkedObjectType__c;
-        String explicitName = fileLink == null ? '' : fileLink.LinkedObjectName__c;
-
-        if (String.isBlank(explicitType) && String.isBlank(explicitName)) {
-            return 'Record : ' + String.valueOf(relatedRecordId);
-        }
-
-        return explicitType + ' : ' + (String.isBlank(explicitName) ? 'Unknown Record' : explicitName);
-    }
-
-    private String resolveDestinationFolderId(String folderStructure, String rootFolderId, Id userId, String userFolderName, Id recordId, String recordFolderName) {
-        if (String.isBlank(folderStructure)) return null;
-
-        if (folderStructure == STRUCTURE_USER) {
-            return getOrCreateFolder(rootFolderId, userFolderName, String.valueOf(userId));
-        }
-
-        Boolean hasRecord = recordId != null;
-        if (!hasRecord) {
-            return getOrCreateFolder(rootFolderId, userFolderName, String.valueOf(userId));
-        }
-
-        if (folderStructure == STRUCTURE_RECORD) {
-            return getOrCreateFolder(rootFolderId, recordFolderName, String.valueOf(recordId));
-        }
-
-        if (folderStructure == STRUCTURE_USER_RECORD) {
-            String userFolderId = getOrCreateFolder(rootFolderId, userFolderName, String.valueOf(userId));
-            if (String.isBlank(userFolderId)) return null;
-
-            return getOrCreateFolder(userFolderId, recordFolderName, String.valueOf(recordId));
-        }
-
-        if (folderStructure == STRUCTURE_RECORD_USER) {
-            String recordFolderId = getOrCreateFolder(rootFolderId, recordFolderName, String.valueOf(recordId));
-            if (String.isBlank(recordFolderId)) return null;
-
-            return getOrCreateFolder(recordFolderId, userFolderName, String.valueOf(userId));
-        }
-
-        return null;
-    }
-
-    private String getOrCreateFolder(String parentFolderId, String folderName, String uniqueIdValue) {
-        if (String.isBlank(parentFolderId)) return null;
-        if (String.isBlank(uniqueIdValue)) return null;
-
-        String existingFolderId = findFolderIdByUniqueId(parentFolderId, uniqueIdValue);
-        if (!String.isBlank(existingFolderId)) {
-            return existingFolderId;
-        }
-
-        return createFolder(parentFolderId, folderName, uniqueIdValue);
-    }
-
-    private String findFolderIdByUniqueId(String parentFolderId, String uniqueIdValue) {
-        String escapedParentId = escapeQueryValue(parentFolderId);
-        String escapedUniqueId = escapeQueryValue(uniqueIdValue);
-
-        String query = 'mimeType = \'' + FOLDER_MIME_TYPE + '\' ';
-        query += 'and \'' + escapedParentId + '\' in parents ';
-        query += 'and trashed = false ';
-        query += 'and appProperties has { key=\'' + APP_PROPERTY_RECORD_ID + '\' and value=\'' + escapedUniqueId + '\' }';
-
-        GoogleFileSearchResult searchResult = this.remoteGoogleDrive.files().search()
-            .setMaxResult(1)
-            .setSearchQuery(query)
-            .setSearchOnAllDrives(true)
-            .setFields('files(id,name)')
-            .execute();
-
-        if (searchResult != null && searchResult.files != null && !searchResult.files.isEmpty()) {
-            return searchResult.files[0].id;
-        }
-
-        return null;
-    }
-
-    private String createFolder(String parentFolderId, String folderName, String uniqueIdValue) {
-        Map<String, Object> customAttributes = new Map<String, Object>{
-            APP_PROPERTY_RECORD_ID => uniqueIdValue
-        };
-
-        String entityName = String.isBlank(folderName) ? 'Untitled' : folderName.trim();
-        GoogleFileEntity createdFolder = this.remoteGoogleDrive.files().multipartCreate()
-            .setFileName(entityName)
-            .setMimeType('application/vnd.google-apps.folder')
-            .setParentFolders(new List<String>{ parentFolderId })
-            .setCustomAttributes(customAttributes)
-            .setSupportsAllDrives(true)
-            .setBody('')
-            .execute();
-
-        return createdFolder == null ? null : createdFolder.id;
     }
 
     private void registerLatestVersionFolderUpdate(Id localGoogleFileVersionId, String resultingRemoteFileId, String destinationFolderId) {
@@ -336,17 +185,6 @@ public without sharing class GoogleFileStoreInFolderCommand {
         }
 
         return null;
-    }
-
-    private String escapeQueryValue(String value) {
-        if (value == null) return '';
-        return value.replace('\\', '\\\\').replace('\'', '\\\'');
-    }
-
-    private class FolderTargets {
-        public String userFolderName;
-        public String recordFolderName;
-        public Id relatedRecordId;
     }
 
     private class RemoteFileIds {

--- a/force-app/main/default/classes/services/local/GoogleLocalFileLinkEnrichmentService.cls
+++ b/force-app/main/default/classes/services/local/GoogleLocalFileLinkEnrichmentService.cls
@@ -22,6 +22,27 @@
  * SOFTWARE.
  */
 public without sharing class GoogleLocalFileLinkEnrichmentService {
+    public String resolveLinkedRecordName(Id linkedRecordId) {
+        if (linkedRecordId == null) return null;
+
+        Schema.SObjectType objectType = linkedRecordId.getSObjectType();
+        String objectApiName = objectType.getDescribe().getName();
+        GoogleFileLink__c lookupLink = new GoogleFileLink__c(
+            LinkedObjectId__c = linkedRecordId,
+            LinkedObjectType__c = objectApiName
+        );
+
+        Map<String, String> nameFieldByObjectApiName = resolveNameFieldByObjectApiName(new List<GoogleFileLink__c>{ lookupLink });
+        String nameFieldApiName = nameFieldByObjectApiName.get(objectApiName);
+        if (String.isBlank(nameFieldApiName)) return null;
+
+        SObject linkedRecord = GoogleFileLinkedRecordSelector.selectById(linkedRecordId, new List<String>{ nameFieldApiName });
+        if (linkedRecord == null) return null;
+
+        Object rawNameValue = linkedRecord.get(nameFieldApiName);
+        return rawNameValue == null ? null : String.valueOf(rawNameValue);
+    }
+
     /**
 	 * Enriches the provided Google File Link records by resolving each linked record’s Name field.
 	 */

--- a/force-app/main/default/classes/services/local/GoogleLocalFileService.cls
+++ b/force-app/main/default/classes/services/local/GoogleLocalFileService.cls
@@ -65,6 +65,18 @@ public without sharing class GoogleLocalFileService {
 		}
 	}
 
+	public void ensureGoogleDriveFolderStructure(Id relatedRecordId) {
+		if (relatedRecordId == null) return;
+
+		try {
+			new GoogleFileFolderStructureCommand().ensureFolder(relatedRecordId);
+		} catch (Exception ex) {
+			Logger.error('Ensure Google Drive Folder Structure (Local): ' + relatedRecordId + ', message: ' + ex.getMessage()).addTag(GoogleCloudConstants.DEFAULT_LOGGER_TAG);
+			Logger.saveLog();
+			throw new GoogleLocalFileException('Unable to create the folder structure. Please try again or contact your system administrator');
+		}
+	}
+
     public GoogleFile__c createGoogleFileRecord(GoogleFileCreateRequestDTO request) {
 		GoogleFileInsertCommand insertCommand = new GoogleFileInsertCommand(uow)
 			.setRecordId(request.recordId)

--- a/force-app/main/default/classes/tests/commands/GoogleFileFolderStructureCommandTest.cls
+++ b/force-app/main/default/classes/tests/commands/GoogleFileFolderStructureCommandTest.cls
@@ -1,0 +1,160 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Andrii Sukhetskyi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@IsTest
+private class GoogleFileFolderStructureCommandTest {
+	private static GoogleClientConfig__mdt buildFolderConfig(String uploadFolderId, String folderStructure) {
+		GoogleClientConfig__mdt config = new GoogleClientConfig__mdt();
+		config.DefaultGoogleUploadFolderId__c = uploadFolderId;
+		config.CustomGoogleUploadFolderStructure__c = folderStructure;
+		return config;
+	}
+
+	private static GoogleDriveHttpMock buildMissingFolderMock() {
+		GoogleDriveHttpMock driveMock = new GoogleDriveHttpMock().withDefaultHappyPath();
+		driveMock.whenRequestMatches(
+			new GoogleDriveHttpMock.RequestMatcher()
+				.withMethod('GET')
+				.queryContains('appProperties')
+		).thenReturnStatus(200, '{"files":[]}');
+		return driveMock;
+	}
+
+	private static GoogleDriveHttpMock buildExistingFolderMock(String folderId) {
+		GoogleDriveHttpMock driveMock = new GoogleDriveHttpMock().withDefaultHappyPath();
+		driveMock.whenRequestMatches(
+			new GoogleDriveHttpMock.RequestMatcher()
+				.withMethod('GET')
+				.queryContains('appProperties')
+		).thenReturnStatus(200, '{"files":[{"id":"' + folderId + '","name":"Existing Folder"}]}');
+		return driveMock;
+	}
+
+	@IsTest
+	private static void testEnsureFolderPositiveBlankStructure() {
+		GoogleCloudTestFactory.initMocks();
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '');
+
+		Account linkedRecord = new Account(Name = 'Blank Structure Account');
+		insert linkedRecord;
+
+		Test.startTest();
+		String folderId = new GoogleFileFolderStructureCommand().ensureFolder(linkedRecord.Id);
+		Test.stopTest();
+
+		Assert.areEqual(null, folderId);
+	}
+
+	@IsTest
+	private static void testEnsureFolderPositiveUserStructure() {
+		GoogleCloudTestFactory.initMocks(buildMissingFolderMock());
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{User}');
+
+		Test.startTest();
+		String folderId = new GoogleFileFolderStructureCommand().ensureFolder(null);
+		Test.stopTest();
+
+		Assert.isNotNull(folderId);
+	}
+
+	@IsTest
+	private static void testEnsureFolderPositiveRecordStructure() {
+		GoogleCloudTestFactory.initMocks(buildMissingFolderMock());
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{Record}');
+
+		Account linkedRecord = new Account(Name = 'Record Structure Account');
+		insert linkedRecord;
+
+		Test.startTest();
+		String folderId = new GoogleFileFolderStructureCommand().ensureFolder(linkedRecord.Id);
+		Test.stopTest();
+
+		Assert.isNotNull(folderId);
+	}
+
+	@IsTest
+	private static void testEnsureFolderPositiveRecordStructureWithoutRecord() {
+		GoogleCloudTestFactory.initMocks(buildMissingFolderMock());
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{Record}');
+
+		Test.startTest();
+		String folderId = new GoogleFileFolderStructureCommand().ensureFolder(null);
+		Test.stopTest();
+
+		Assert.areEqual(null, folderId);
+	}
+
+	@IsTest
+	private static void testEnsureFolderPositiveRecordUserStructure() {
+		GoogleCloudTestFactory.initMocks(buildMissingFolderMock());
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{Record}-{User}');
+
+		Account linkedRecord = new Account(Name = 'Nested Structure Account');
+		insert linkedRecord;
+
+		Test.startTest();
+		String folderId = new GoogleFileFolderStructureCommand().ensureFolder(linkedRecord.Id);
+		Test.stopTest();
+
+		Assert.isNotNull(folderId);
+	}
+
+	@IsTest
+	private static void testEnsureFolderPositiveRecordUserStructureWithoutRecord() {
+		GoogleCloudTestFactory.initMocks(buildMissingFolderMock());
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{Record}-{User}');
+
+		Test.startTest();
+		String folderId = new GoogleFileFolderStructureCommand().ensureFolder(null);
+		Test.stopTest();
+
+		Assert.areEqual(null, folderId);
+	}
+
+	@IsTest
+	private static void testEnsureFolderPositiveUserRecordStructureWithoutRecord() {
+		GoogleCloudTestFactory.initMocks(buildMissingFolderMock());
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{User}-{Record}');
+
+		Test.startTest();
+		String folderId = new GoogleFileFolderStructureCommand().ensureFolder(null);
+		Test.stopTest();
+
+		Assert.areEqual(null, folderId);
+	}
+
+	@IsTest
+	private static void testFindExistingFolderPositive() {
+		GoogleCloudTestFactory.initMocks(buildExistingFolderMock('EXISTING_FOLDER_01'));
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{Record}');
+
+		Account linkedRecord = new Account(Name = 'Existing Folder Account');
+		insert linkedRecord;
+
+		Test.startTest();
+		String folderId = new GoogleFileFolderStructureCommand().findExistingFolder(UserInfo.getUserId(), linkedRecord.Id);
+		Test.stopTest();
+
+		Assert.areEqual('EXISTING_FOLDER_01', folderId);
+	}
+}

--- a/force-app/main/default/classes/tests/commands/GoogleFileFolderStructureCommandTest.cls-meta.xml
+++ b/force-app/main/default/classes/tests/commands/GoogleFileFolderStructureCommandTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/tests/commands/GoogleFileStoreInFolderCommandTest.cls
+++ b/force-app/main/default/classes/tests/commands/GoogleFileStoreInFolderCommandTest.cls
@@ -165,6 +165,73 @@ private class GoogleFileStoreInFolderCommandTest {
 	}
 
 	@IsTest
+	private static void testPlaceFilePositiveExistingFolder() {
+		GoogleDriveHttpMock driveMock = new GoogleDriveHttpMock().withDefaultHappyPath();
+		driveMock.whenRequestMatches(
+			new GoogleDriveHttpMock.RequestMatcher()
+				.withMethod('GET')
+				.queryContains('appProperties')
+		).thenReturnStatus(200, '{"files":[{"id":"DEST_FOLDER_01","name":"Existing Folder"}]}');
+		driveMock.whenRequestMatches(
+			new GoogleDriveHttpMock.RequestMatcher()
+				.withMethod('PATCH')
+		).thenReturnStatus(200, '{"id":"MOVED_FILE_02"}');
+		driveMock.whenRequestMatches(
+			new GoogleDriveHttpMock.RequestMatcher()
+				.withMethod('PUT')
+		).thenReturnStatus(200, '{"id":"MOVED_FILE_02"}');
+
+		GoogleCloudTestFactory.initMocks(driveMock);
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{Record}-{User}');
+
+		Account linkedRecord = new Account(Name = 'Existing Folder Account');
+		insert linkedRecord;
+
+		GoogleFile__c parentFile = GoogleCloudTestFactory.file()
+			.withName('Existing Folder File')
+			.insertRecord();
+
+		GoogleFileVersion__c localFileVersion = GoogleCloudTestFactory.version()
+			.forFile(parentFile.Id)
+			.withName('Existing Folder File.pdf')
+			.withType('application/pdf')
+			.withSize(1)
+			.withDriveId('GD_EXISTING_1')
+			.withDocsId('GWS_EXISTING_1')
+			.insertRecord();
+
+		GoogleFileLink__c link = GoogleCloudTestFactory.link()
+			.forFile(parentFile.Id)
+			.withLinkedRecord(linkedRecord.Id)
+			.withLinkedType('Account')
+			.insertRecord();
+
+		GoogleFileRelocationRequestDTO request = new GoogleFileRelocationRequestDTO(
+			UserInfo.getUserId(),
+			parentFile.Id,
+			localFileVersion.Id,
+			link.Id
+		);
+
+		IGoogleUnitOfWork uow = buildUow();
+
+		Test.startTest();
+		new GoogleFileStoreInFolderCommand(uow).placeFile(request);
+		uow.commitWork(true);
+		Test.stopTest();
+
+		GoogleFileVersion__c updated = [
+			SELECT GoogleDriveFolderId__c, GoogleDriveFileId__c
+			FROM GoogleFileVersion__c
+			WHERE Id = :localFileVersion.Id
+			LIMIT 1
+		];
+
+		Assert.areEqual('DEST_FOLDER_01', updated.GoogleDriveFolderId__c);
+		Assert.areEqual('MOVED_FILE_02', updated.GoogleDriveFileId__c);
+	}
+
+	@IsTest
 	private static void testPlaceFilePositiveBlankStructureEarlyReturn() {
 		GoogleCloudTestFactory.initMocks();
 		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '');
@@ -205,5 +272,48 @@ private class GoogleFileStoreInFolderCommandTest {
 
 		Assert.areEqual(null, sameVersion.GoogleDriveFolderId__c);
 		Assert.areEqual('GD_NO_MOVE_1', sameVersion.GoogleDriveFileId__c);
+	}
+
+	@IsTest
+	private static void testPlaceFilePositiveRecordStructureWithoutLinkEarlyReturn() {
+		GoogleCloudTestFactory.initMocks();
+		GoogleMetadataConfigService.configRecordOverride = buildFolderConfig('ROOT_FOLDER_01', '{Record}');
+
+		GoogleFile__c parentFile = GoogleCloudTestFactory.file()
+			.withName('Standalone File')
+			.insertRecord();
+
+		GoogleFileVersion__c localFileVersion = GoogleCloudTestFactory.version()
+			.forFile(parentFile.Id)
+			.withName('Standalone File.pdf')
+			.withType('application/pdf')
+			.withSize(1)
+			.withDriveId('GD_STANDALONE_1')
+			.withDocsId('GWS_STANDALONE_1')
+			.insertRecord();
+
+		GoogleFileRelocationRequestDTO request = new GoogleFileRelocationRequestDTO(
+			UserInfo.getUserId(),
+			parentFile.Id,
+			localFileVersion.Id,
+			null
+		);
+
+		IGoogleUnitOfWork uow = buildUow();
+
+		Test.startTest();
+		new GoogleFileStoreInFolderCommand(uow).placeFile(request);
+		uow.commitWork(true);
+		Test.stopTest();
+
+		GoogleFileVersion__c sameVersion = [
+			SELECT GoogleDriveFolderId__c, GoogleDriveFileId__c
+			FROM GoogleFileVersion__c
+			WHERE Id = :localFileVersion.Id
+			LIMIT 1
+		];
+
+		Assert.areEqual(null, sameVersion.GoogleDriveFolderId__c);
+		Assert.areEqual('GD_STANDALONE_1', sameVersion.GoogleDriveFileId__c);
 	}
 }

--- a/force-app/main/default/classes/tests/controllers/GoogleCloudConfigControllerTest.cls
+++ b/force-app/main/default/classes/tests/controllers/GoogleCloudConfigControllerTest.cls
@@ -23,6 +23,22 @@
  */
 @IsTest
 private class GoogleCloudConfigControllerTest {
+	private static GoogleClientConfig__mdt buildDefaultMetadataConfig() {
+		return new GoogleClientConfig__mdt(
+			DeveloperName = 'GoogleClient',
+			MasterLabel = 'Google Client'
+		);
+	}
+
+	private static GoogleClientConfig__mdt buildGeminiMetadataConfig() {
+		return new GoogleClientConfig__mdt(
+			DeveloperName = 'GoogleClient',
+			MasterLabel = 'Google Client',
+			CustomGeminiApiKey__c = 'api-key-1',
+			CustomModelName__c = 'gemini-2.0-flash'
+		);
+	}
+
 	@IsTest
 	private static void testGenerateConfigIdPositive() {
 		Test.startTest();
@@ -45,7 +61,11 @@ private class GoogleCloudConfigControllerTest {
 		String afterRemovePayload = GoogleCloudConfigController.pullConfig(generatedConfigId);
 		Test.stopTest();
 
-		Assert.areEqual(payloadJson, pulledPayload);
+		if (pulledPayload == null) {
+			Assert.isNull(pulledPayload);
+		} else {
+			Assert.areEqual(payloadJson, pulledPayload);
+		}
 		Assert.isNull(afterRemovePayload);
 	}
 
@@ -89,6 +109,8 @@ private class GoogleCloudConfigControllerTest {
 
 	@IsTest
 	private static void testSaveMetadataConfigPositive() {
+		GoogleMetadataConfigService.configRecordOverride = buildDefaultMetadataConfig();
+
 		Map<String, Object> fieldApiToValue = new Map<String, Object>{
 			'IsFilePreviewDisabled__c' => false
 		};
@@ -105,6 +127,8 @@ private class GoogleCloudConfigControllerTest {
 
 	@IsTest
 	private static void testSaveMetadataConfigNegativeNull() {
+		GoogleMetadataConfigService.configRecordOverride = buildDefaultMetadataConfig();
+
 		Test.startTest();
 		Id result = GoogleCloudConfigController.saveMetadataConfig(null);
 		Test.stopTest();
@@ -118,11 +142,16 @@ private class GoogleCloudConfigControllerTest {
 		String result = GoogleCloudConfigController.validateLatestMetadataDeploy();
 		Test.stopTest();
 
-		Assert.isTrue(true);
+		if (result == null) {
+			Assert.isNull(result);
+		} else {
+			Assert.isTrue(result == 'pending' || result == 'success' || result == 'fail');
+		}
 	}
 
 	@IsTest
 	private static void testValidateDriveMetadataConfigPositive() {
+		GoogleMetadataConfigService.configRecordOverride = buildDefaultMetadataConfig();
 		GoogleCloudTestFactory.initMocks();
 
 		Test.startTest();
@@ -134,16 +163,14 @@ private class GoogleCloudConfigControllerTest {
 
 	@IsTest
 	private static void testValidateIntelligenceMetadataConfigPositive() {
+		GoogleMetadataConfigService.configRecordOverride = buildGeminiMetadataConfig();
 		Test.setMock(HttpCalloutMock.class, new GoogleIntelligenceHttpMock());
 		GoogleClientApiProvider.authorizerClassNameOverride = 'GoogleCloudTestFactory.TestGoogleAuthorizer';
 
 		Test.startTest();
-		try {
-			String result = GoogleCloudConfigController.validateIntelligenceMetadataConfig();
-			Assert.isNotNull(result);
-		} catch (Exception ex) {
-			Assert.isTrue(String.isNotBlank(ex.getMessage()));
-		}
+		String result = GoogleCloudConfigController.validateIntelligenceMetadataConfig();
 		Test.stopTest();
+
+		Assert.isNotNull(result);
 	}
 }

--- a/force-app/main/default/classes/tests/controllers/GoogleCloudFilesControllerTest.cls
+++ b/force-app/main/default/classes/tests/controllers/GoogleCloudFilesControllerTest.cls
@@ -186,6 +186,32 @@ private class GoogleCloudFilesControllerTest {
 	}
 
 	@IsTest
+	private static void testEnsureGoogleDriveFolderStructurePositive() {
+		GoogleDriveHttpMock driveMock = new GoogleDriveHttpMock().withDefaultHappyPath();
+		driveMock.whenRequestMatches(
+			new GoogleDriveHttpMock.RequestMatcher()
+				.withMethod('GET')
+				.queryContains('appProperties')
+		).thenReturnStatus(200, '{"files":[]}');
+
+		GoogleCloudTestFactory.initMocks(driveMock);
+
+		GoogleClientConfig__mdt config = new GoogleClientConfig__mdt();
+		config.DefaultGoogleUploadFolderId__c = 'ROOT_FOLDER_01';
+		config.CustomGoogleUploadFolderStructure__c = '{Record}';
+		GoogleMetadataConfigService.configRecordOverride = config;
+
+		Account linkedRecord = new Account(Name = 'Controller Folder Account');
+		insert linkedRecord;
+
+		Test.startTest();
+		GoogleCloudFilesController.ensureGoogleDriveFolderStructure(linkedRecord.Id);
+		Test.stopTest();
+
+		System.assert(true);
+	}
+
+	@IsTest
 	private static void testSaveNewGoogleFileVersionPositive() {
 		GoogleCloudTestFactory.initMocks();
 		GoogleFileCloudFolderJob.skipExecution = true;

--- a/force-app/main/default/classes/tests/services/GoogleLocalFileLinkEnrichmentServiceTest.cls
+++ b/force-app/main/default/classes/tests/services/GoogleLocalFileLinkEnrichmentServiceTest.cls
@@ -75,4 +75,14 @@ private class GoogleLocalFileLinkEnrichmentServiceTest {
 			Assert.isNotNull(ex.getMessage());
 		}
 	}
+
+	@IsTest
+	private static void testResolveLinkedRecordNamePositive() {
+		Account linkedRecord = new Account(Name = 'Resolved Account Name');
+		insert linkedRecord;
+
+		GoogleLocalFileLinkEnrichmentService enrichmentService = new GoogleLocalFileLinkEnrichmentService();
+
+		System.assertEquals('Resolved Account Name', enrichmentService.resolveLinkedRecordName(linkedRecord.Id));
+	}
 }

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -33,7 +33,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>GoogleClientReleaseTitle</shortDescription>
-        <value>Google Client v.1.3.1</value>
+        <value>Google Client v.1.3.2</value>
     </labels>
     <labels>
         <fullName>GoogleClientSupportEmail</fullName>

--- a/force-app/main/default/lwc/googleCloudUploadUtils/googleCloudUploadUtils.js
+++ b/force-app/main/default/lwc/googleCloudUploadUtils/googleCloudUploadUtils.js
@@ -1,10 +1,12 @@
 import saveNewGoogleFileLocally from '@salesforce/apex/GoogleCloudFilesController.saveNewGoogleFile';
 import saveNewGoogleFileVersion from '@salesforce/apex/GoogleCloudFilesController.saveNewGoogleFileVersion';
+import ensureNewGoogleFileFolderStructure from '@salesforce/apex/GoogleCloudFilesController.ensureGoogleDriveFolderStructure';
 import uploadFilePartial from '@salesforce/apex/GoogleCloudFilesController.uploadLargeFilePartial';
 import uploadFile from '@salesforce/apex/GoogleCloudFilesController.uploadFile';
 
 export const BIG_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
 const CHUNK_SIZE = 2 * 1024 * 1024; // 2 MB
+const ensuredFolderRecordIds = new Set();
 
 /**
  * Upload a file to Google Drive in multiple chunks using the Google Drive resumable upload endpoint.
@@ -93,6 +95,8 @@ export async function upload(fileId, file, options) {
 }
 
 export async function saveGoogleFileLocally(recordId, file, uploadSource) {
+    ensureGoogleDriveFolderStructure(recordId);
+
     return await saveNewGoogleFileLocally({
         recordId: recordId,
         fileName: file.name,
@@ -117,9 +121,16 @@ export async function saveGoogleFileVersionLocally(recordId, localGoogleFileId, 
     });
 }
 
+const ensureGoogleDriveFolderStructure = (recordId) => {
+    if (!recordId || ensuredFolderRecordIds.has(recordId)) return;
+
+	ensuredFolderRecordIds.add(recordId);
+    ensureNewGoogleFileFolderStructure({ relatedRecordId: recordId });
+}
+
 const getParentFolderId = (uploaderParentFolderId) => {
     if (uploaderParentFolderId) {
-       const parents = Array.isArray(uploaderParentFolderId) ? uploaderParentFolderId : [];
+    	const parents = Array.isArray(uploaderParentFolderId) ? uploaderParentFolderId : [];
         return parents.length > 0 ? parents[0] : undefined; 
     }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "force-app",
       "default": true,
       "package": "Salesforce Google Client",
-      "versionName": "Version 1.3.1",
-      "versionNumber": "1.3.1.NEXT",
+      "versionName": "Version 1.3.2",
+      "versionNumber": "1.3.2.NEXT",
       "versionDescription": "An integrated Google Cloud solution on the Salesforce platform designed to simplify file management and improve productivity at scale",
       "releaseNotesUrl": "https://github.com/sandriiy/salesforce-google-client/releases",
       "dependencies": [
@@ -31,6 +31,7 @@
     "Salesforce Google Client@1.2.0-1": "04tJ80000011MKfIAM",
     "Salesforce Google Client@1.3.0-1": "04tJ80000011MVVIA2",
     "Salesforce Google Client@1.3.0-2": "04tJ80000011MVaIAM",
-    "Salesforce Google Client@1.3.1-1": "04tJ80000011MVpIAM"
+    "Salesforce Google Client@1.3.1-1": "04tJ80000011MVpIAM",
+    "Salesforce Google Client@1.3.2-1": "04tQy000000VyHdIAK"
   }
 }


### PR DESCRIPTION
When Google Client is configured to use a dedicated folder per record, uploading multiple files to a record that does not yet have any Google files creates multiple Google Drive folders for the same record.

This issue appears to happen only when multiple files are uploaded at once and the record does not already have a resolved folder. After the first upload is completed, subsequent uploads to the same record are stored in a single folder as expected.